### PR TITLE
chore: Upgrade arti_client to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,38 +1,23 @@
 [package]
 name = "libp2p-community-tor"
-version = "0.3.0-alpha"
+version = "0.1.0"
 edition = "2021"
+description = "Tor transport for libp2p"
+repository = "https://github.com/hannes-furmans/libp2p-community-tor"
 license = "MIT"
-resolver = "2"
-description = "Tor transport for libp2p."
-repository = "https://github.com/umgefahren/libp2p-tor"
-authors = ["umgefahren <hannes@umgefahren.xyz>"]
+keywords = ["libp2p", "tor", "p2p", "networking"]
+categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-arti-client = { version = "0.24", default-features = false }
-async-std-crate = { package = "async-std", version = "1", optional = true, default-features = false }
+arti-client = "0.24.0"
 futures = "0.3"
-libp2p-core = { version = "0.39" }
-thiserror = "1"
-tokio-crate = { package = "tokio", version = "1", optional = true, default-features = false }
-tor-rtcompat = "0.8"
+libp2p = { version = "0.53", default-features = false, features = ["tokio", "tcp", "tls"] }
+tor-rtcompat = { version = "0.24.0", features = ["tokio", "rustls"] }
+tokio = { version = "1.0", features = ["io-util", "rt", "rt-multi-thread", "macros"] }
 
 [dev-dependencies]
-libp2p = { version = "0.51", features = ["mplex", "noise", "ping", "yamux", "macros", "async-std"] }
-tokio-crate = { package = "tokio", version = "1", features = ["rt", "macros"] }
-async-std-crate = { package = "async-std", version = "1", features = ["attributes"] }
-
-[features]
-tokio = ["arti-client/tokio", "dep:tokio-crate"]
-async-std = ["arti-client/async-std", "dep:async-std-crate"]
-native-tls = ["arti-client/native-tls"]
-rustls = ["arti-client/rustls"]
-
-[[example]]
-name = "ping-onion"
-required-features = ["async-std", "rustls"]
+libp2p = { version = "0.53", default-features = false, features = ["tokio", "noise", "yamux", "ping", "noise", "macros", "tcp", "tls"] }
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/umgefahren/libp2p-tor"
 authors = ["umgefahren <hannes@umgefahren.xyz>"]
 
 [dependencies]
-arti-client = { version = "0.8", default-features = false }
+arti-client = { version = "0.24", default-features = false }
 async-std-crate = { package = "async-std", version = "1", optional = true, default-features = false }
 futures = "0.3"
 libp2p-core = { version = "0.39" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tracing = "0.1.40"
 
 [dev-dependencies]
 libp2p = { version = "0.53", default-features = false, features = ["tokio", "noise", "yamux", "ping", "noise", "macros", "tcp", "tls"] }
+tokio-test = "0.4.4"
 
 [[example]]
 name = "ping-onion"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-community-tor"
-version = "0.2.0"
+version = "0.4.0"
 edition = "2021"
 description = "Tor transport for libp2p"
 repository = "https://github.com/hannes-furmans/libp2p-community-tor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ futures = "0.3"
 libp2p = { version = "0.53", default-features = false, features = ["tokio", "tcp", "tls"] }
 tor-rtcompat = { version = "0.24.0", features = ["tokio", "rustls"] }
 tokio = { version = "1.0", features = ["io-util", "rt", "rt-multi-thread", "macros"] }
+tracing = "0.1.40"
 
 [dev-dependencies]
 libp2p = { version = "0.53", default-features = false, features = ["tokio", "noise", "yamux", "ping", "noise", "macros", "tcp", "tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-community-tor"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Tor transport for libp2p"
 repository = "https://github.com/hannes-furmans/libp2p-community-tor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ tracing = "0.1.40"
 [dev-dependencies]
 libp2p = { version = "0.53", default-features = false, features = ["tokio", "noise", "yamux", "ping", "noise", "macros", "tcp", "tls"] }
 
+[[example]]
+name = "ping-onion"
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,18 +2,18 @@
 name = "libp2p-community-tor"
 version = "0.4.0"
 edition = "2021"
-description = "Tor transport for libp2p"
-repository = "https://github.com/hannes-furmans/libp2p-community-tor"
 license = "MIT"
-keywords = ["libp2p", "tor", "p2p", "networking"]
-categories = ["network-programming", "asynchronous"]
+resolver = "2"
+description = "Tor transport for libp2p."
+repository = "https://github.com/umgefahren/libp2p-tor"
+authors = ["umgefahren <hannes@umgefahren.xyz>"]
 
 [dependencies]
 arti-client = "0.24.0"
 futures = "0.3"
-libp2p = { version = "0.53", default-features = false, features = ["tokio", "tcp", "tls"] }
+libp2p = { version = "^0.53", default-features = false, features = ["tokio", "tcp", "tls"] }
 tor-rtcompat = { version = "0.24.0", features = ["tokio", "rustls"] }
-tokio = { version = "1.0", features = ["io-util", "rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.0", features = ["macros"] }
 tracing = "0.1.40"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -21,31 +21,20 @@ are dealing with.
 
 ### Add to your dependencies
 
-This won't work:
 ```bash
-cargo add libp2p-community-tor@0.3.0-alpha
+cargo add libp2p-community-tor
 ```
 
-You have to choose a TLS provider **and** a runtime.
-The TLS providers are:
+This crate uses tokio with rustls for its runtime and TLS implementation.
+No other combinations are supported.
 
 - [`rustls`](https://github.com/rustls/rustls)
-- [`native-tls`](https://github.com/sfackler/rust-native-tls)
-
-The runtimes are:
-
 - [`tokio`](https://github.com/tokio-rs/tokio)
-- [`async-std`](https://github.com/async-rs/async-std)
-
-|               | **rustls**                                                       | **native-tls**                                                       |
-|---------------|------------------------------------------------------------------|----------------------------------------------------------------------|
-| **tokio**     | `cargo add libp2p-community-tor@0.3.0-alpha -F tokio,rustls`     | `cargo add libp2p-community-tor@0.3.0-alpha -F tokio,native-tls`     |
-| **async-std** | `cargo add libp2p-community-tor@0.3.0-alpha -F async-std,rustls` | `cargo add libp2p-community-tor@0.3.0-alpha -F async-std,native-tls` |
 
 ### Example
 ```rust
 let address = "/dns/www.torproject.org/tcp/1000".parse()?;
-let mut transport = libp2p_community_tor::AsyncStdNativeTlsTorTransport::bootstrapped().await?;
+let mut transport = libp2p_community_tor::TorTransport::bootstrapped().await?;
 // we have achieved tor connection
 let _conn = transport.dial(address)?.await?;
 ```

--- a/examples/ping-onion.rs
+++ b/examples/ping-onion.rs
@@ -125,6 +125,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     loop {
         match swarm.select_next_some().await {
+            SwarmEvent::ConnectionEstablished {
+                endpoint, peer_id, ..
+            } => {
+                println!("Connection established with {peer_id} on {endpoint:?}");
+            }
+            SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
+                println!("Outgoing connection error with {peer_id:?}: {error:?}");
+            }
             SwarmEvent::NewListenAddr { address, .. } => println!("Listening on {address:?}"),
             SwarmEvent::Behaviour(event) => println!("{event:?}"),
             _ => {}

--- a/examples/ping-onion.rs
+++ b/examples/ping-onion.rs
@@ -43,78 +43,79 @@
 //! The two nodes establish a connection, negotiate the ping protocol
 //! and begin pinging each other over Tor.
 
-use async_std_crate as async_std;
-use futures::prelude::*;
-use libp2p::swarm::{keep_alive, NetworkBehaviour, SwarmBuilder, SwarmEvent};
-use libp2p::{core::upgrade, identity, mplex, noise, ping, yamux, Multiaddr, PeerId, Transport};
-use libp2p_community_tor::{AddressConversion, AsyncStdRustlsTorTransport};
+use futures::StreamExt;
+use libp2p::core::upgrade::Version;
+use libp2p::Transport;
+use libp2p::{
+    core::muxing::StreamMuxerBox,
+    identity, noise,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    yamux, Multiaddr, PeerId, SwarmBuilder,
+};
+use libp2p_community_tor::{AddressConversion, TorTransport};
 use std::error::Error;
 
-async fn onion_transport(
-    keypair: identity::Keypair,
-) -> Result<
-    libp2p_core::transport::Boxed<(PeerId, libp2p_core::muxing::StreamMuxerBox)>,
-    Box<dyn Error>,
-> {
-    use std::time::Duration;
-
-    let transport = AsyncStdRustlsTorTransport::bootstrapped()
-        .await?
-        .with_address_conversion(AddressConversion::IpAndDns);
-    Ok(transport
-        .upgrade(upgrade::Version::V1)
-        .authenticate(
-            noise::NoiseAuthenticated::xx(&keypair)
-                .expect("Signing libp2p-noise static DH keypair failed."),
-        )
-        .multiplex(upgrade::SelectUpgrade::new(
-            yamux::YamuxConfig::default(),
-            mplex::MplexConfig::default(),
-        ))
-        .timeout(Duration::from_secs(20))
-        .boxed())
+#[derive(NetworkBehaviour)]
+struct Behaviour {
+    ping: libp2p::ping::Behaviour,
 }
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let addr = std::env::args().nth(1).expect("no multiaddr given");
     let local_key = identity::Keypair::generate_ed25519();
     let local_peer_id = PeerId::from(local_key.public());
-    println!("Local peer id: {:?}", local_peer_id);
+    println!("Local peer id: {local_peer_id}");
 
-    let transport = onion_transport(local_key).await?;
+    let transport = TorTransport::bootstrapped()
+        .await?
+        .with_address_conversion(AddressConversion::IpAndDns)
+        .boxed();
 
-    let mut swarm =
-        SwarmBuilder::with_async_std_executor(transport, Behaviour::default(), local_peer_id)
-            .build();
+    let auth_upgrade = noise::Config::new(&local_key)?;
+    let multiplex_upgrade = yamux::Config::default();
+
+    let transport = transport
+        .upgrade(Version::V1)
+        .authenticate(auth_upgrade)
+        .multiplex(multiplex_upgrade)
+        .map(|(peer, muxer), _| (peer, StreamMuxerBox::new(muxer)))
+        .boxed();
+
+    let mut swarm = SwarmBuilder::with_new_identity()
+        .with_tokio()
+        .with_tcp(
+            Default::default(),
+            (libp2p::tls::Config::new, libp2p::noise::Config::new),
+            libp2p::yamux::Config::default,
+        )
+        .unwrap()
+        .with_other_transport(|_| transport)
+        .unwrap()
+        .with_behaviour(|_| Behaviour {
+            ping: libp2p::ping::Behaviour::default(),
+        })
+        .unwrap()
+        .build();
+
+    // Tell the swarm to listen on all interfaces and a random, OS-assigned
+    // port.
+    swarm
+        .listen_on("/ip4/0.0.0.0/tcp/0".parse().unwrap())
+        .unwrap();
 
     // Dial the peer identified by the multi-address given as the second
     // command-line argument, if any.
-    let remote: Multiaddr = addr.parse()?;
-    swarm.dial(remote)?;
-    println!("Dialed {}", addr);
+    if let Some(addr) = std::env::args().nth(1) {
+        let remote: Multiaddr = addr.parse()?;
+        swarm.dial(remote)?;
+        println!("Dialed {addr}")
+    }
 
     loop {
         match swarm.select_next_some().await {
-            SwarmEvent::ConnectionEstablished { endpoint, .. } => {
-                let endpoint_addr = endpoint.get_remote_address();
-                println!("Connection established to {:?}", endpoint_addr);
-            }
-            SwarmEvent::OutgoingConnectionError { error, .. } => {
-                println!("Error establishing outgoing connection: {:?}", error)
-            }
-            SwarmEvent::Behaviour(event) => println!("{:?}", event),
+            SwarmEvent::NewListenAddr { address, .. } => println!("Listening on {address:?}"),
+            SwarmEvent::Behaviour(event) => println!("{event:?}"),
             _ => {}
         }
     }
-}
-
-/// Our network behaviour.
-///
-/// For illustrative purposes, this includes the [`KeepAlive`](behaviour::KeepAlive) behaviour so a continuous sequence of
-/// pings can be observed.
-#[derive(NetworkBehaviour, Default)]
-struct Behaviour {
-    keep_alive: keep_alive::Behaviour,
-    ping: ping::Behaviour,
 }

--- a/examples/ping-onion.rs
+++ b/examples/ping-onion.rs
@@ -79,11 +79,6 @@ async fn onion_transport(
     Ok(transport)
 }
 
-#[derive(NetworkBehaviour)]
-struct Behaviour {
-    ping: libp2p::ping::Behaviour,
-}
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let local_key = identity::Keypair::generate_ed25519();
@@ -138,4 +133,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
             _ => {}
         }
     }
+}
+
+/// Our network behaviour.
+#[derive(NetworkBehaviour)]
+struct Behaviour {
+    ping: libp2p::ping::Behaviour,
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -19,7 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use arti_client::{DangerouslyIntoTorAddr, IntoTorAddr, TorAddr};
-use libp2p_core::{multiaddr::Protocol, Multiaddr};
+use libp2p::{core::multiaddr::Protocol, Multiaddr};
 use std::net::SocketAddr;
 
 /// "Dangerously" extract a Tor address from the provided [`Multiaddr`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,17 @@ impl TorTransport {
         })
     }
 
+    /// Builds a `TorTransport` from an existing Arti `TorClient`.
+    pub fn from_client(
+        client: Arc<TorClient<TokioRustlsRuntime>>,
+        conversion_mode: AddressConversion,
+    ) -> Self {
+        Self {
+            client,
+            conversion_mode,
+        }
+    }
+
     /// Bootstraps the `TorTransport` into the Tor network.
     ///
     /// # Errors
@@ -146,11 +157,11 @@ impl Transport for TorTransport {
     fn listen_on(
         &mut self,
         _id: ListenerId,
-        _addr: Multiaddr,
+        addr: Multiaddr,
     ) -> Result<(), TransportError<Self::Error>> {
         // although this address might be supported, this is returned in order to not provoke an
         // error when trying to listen on this transport.
-        Err(TransportError::MultiaddrNotSupported(_addr))
+        Err(TransportError::MultiaddrNotSupported(addr))
     }
 
     fn remove_listener(&mut self, _id: ListenerId) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,123 +33,70 @@
 //! Use with caution and at your own risk. **Don't** just blindly advertise Tor without fully understanding what you
 //! are dealing with.
 //!
+//! ## Runtime
+//!
+//! This crate uses tokio with rustls for its runtime and TLS implementation.
+//! No other combinations are supported.
+//!
 //! Main entrypoint of the crate: [`TorTransport`]
-//!
-//! ## Features
-//!
-//! You have to enable a TLS provider **and** a runtime.
-//! The TLS providers are:
-//!
-//! - [`rustls`](https://github.com/rustls/rustls)
-//! - [`native-tls`](https://github.com/sfackler/rust-native-tls)
-//!
-//! The runtimes are:
-//!
-//! - [`tokio`](https://github.com/tokio-rs/tokio)
-//! - [`async-std`](https://github.com/async-rs/async-std)
-//!
-//! With that the transports you have to use are:
-//!
-//! |               | **rustls**                     | **native-tls**                    |
-//! |---------------|--------------------------------|-----------------------------------|
-//! | **tokio**     | [`TokioRustlsTorTransport`]    | [`TokioNativeTlsTorTransport`]    |
-//! | **async-std** | [`AsyncStdRustlsTorTransport`] | [`AsyncStdNativeTlsTorTransport`] |
-//!
-//! ## Example (async-std + native-tls)
-//! ```no_run
-//! # use async_std_crate as async_std;
-//! # use libp2p_core::Transport;
-//! # async fn test_func() -> Result<(), Box<dyn std::error::Error>> {
-//! let address = "/dns/www.torproject.org/tcp/1000".parse()?;
-//! let mut transport = libp2p_community_tor::AsyncStdNativeTlsTorTransport::bootstrapped().await?;
-//! // we have achieved tor connection
-//! let _conn = transport.dial(address)?.await?;
-//! # Ok(())
-//! # }
-//! # async_std::task::block_on(async { test_func().await.unwrap() });
-//! ```
 
-use address::{dangerous_extract, safe_extract};
-use arti_client::{TorClient, TorClientBuilder};
-use futures::{future::BoxFuture, FutureExt};
-use libp2p_core::{transport::TransportError, Multiaddr, Transport};
+use arti_client::{DataStream, TorClient, TorClientBuilder};
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use libp2p::{
+    core::transport::{ListenerId, TransportEvent},
+    tcp::tokio::TcpStream,
+    Multiaddr, PeerId, Transport, TransportError,
+};
 use provider::TorStream;
 use std::sync::Arc;
-use std::{marker::PhantomData, pin::Pin};
-use tor_rtcompat::Runtime;
+use tor_rtcompat::tokio::TokioRustlsRuntime;
 
 mod address;
 mod provider;
 
-#[cfg(feature = "tokio")]
-#[doc(inline)]
+use address::{dangerous_extract, safe_extract};
 pub use provider::TokioTorStream;
-
-#[cfg(feature = "async-std")]
-#[doc(inline)]
-pub use provider::AsyncStdTorStream;
 
 pub type TorError = arti_client::Error;
 
 #[derive(Clone)]
-pub struct TorTransport<R, S>
-where
-    R: Runtime
-        + BlockOn
-        + SleepProvider
-        + UdpProvider
-        + CoarseTimeProvider
-        + NetStreamProvider
-        + NetStreamProvider<std::os::unix::net::SocketAddr>
-        + TlsProvider<S>,
-    S: TorStream,
-{
-    // client is in an Arc, because without it the [`Transport::dial`] method can't be implemented,
-    // due to lifetime issues. With the, eventual, stabilization of static async traits this issue
-    // will be resolved.
-    client: Arc<TorClient<R>>,
-    /// The used conversion mode to resolve addresses. One probably shouldn't access this directly.
-    /// The usage of [TorTransport::with_address_conversion] at construction is recommended.
+pub struct TorTransport {
+    client: Arc<TorClient<TokioRustlsRuntime>>,
     pub conversion_mode: AddressConversion,
-    phantom: PhantomData<S>,
 }
 
-/// Configure the onion transport from here.
-pub type TorBuilder<R> = TorClientBuilder<R>;
+impl TorTransport {
+    pub fn builder() -> TorBuilder<TokioRustlsRuntime> {
+        let runtime =
+            TokioRustlsRuntime::current().expect("Couldn't get the current tokio rustls runtime");
+        TorClient::with_runtime(runtime)
+    }
 
-/// Mode of address conversion. Refer tor [arti_client::TorAddr](https://docs.rs/arti-client/latest/arti_client/struct.TorAddr.html) for details.
-#[derive(Debug, Clone, Copy, Hash, Default, PartialEq, Eq, PartialOrd, Ord)]
-pub enum AddressConversion {
-    /// Uses only dns for address resolution (default).
-    #[default]
-    DnsOnly,
-    /// uses ip and dns for addresses
-    IpAndDns,
-}
-
-impl<R: Runtime, S> TorTransport<R, S> {
-    /// Builds a `TorTransport` from an Arti `TorClientBuilder`.
+    /// Creates a bootstrapped `TorTransport`
     ///
     /// # Errors
-    ///
-    /// Could return errors emitted from Arti.
+    /// Could return error emitted during Tor bootstrap by Arti.
+    pub async fn bootstrapped() -> Result<Self, TorError> {
+        let builder = Self::builder();
+        let ret = Self::from_builder(builder, AddressConversion::DnsOnly)?;
+        ret.bootstrap().await?;
+        Ok(ret)
+    }
+
+    /// Builds a `TorTransport` from an Arti `TorClientBuilder`.
     pub fn from_builder(
-        builder: TorBuilder<R>,
+        builder: TorBuilder<TokioRustlsRuntime>,
         conversion_mode: AddressConversion,
     ) -> Result<Self, TorError> {
         let client = Arc::new(builder.create_unbootstrapped()?);
         Ok(Self {
             client,
             conversion_mode,
-            phantom: PhantomData::default(),
         })
     }
 
     /// Bootstraps the `TorTransport` into the Tor network.
-    ///
-    /// # Errors
-    ///
-    /// Could return error emitted during bootstrap by Arti.
     pub async fn bootstrap(&self) -> Result<(), TorError> {
         self.client.bootstrap().await
     }
@@ -162,115 +109,34 @@ impl<R: Runtime, S> TorTransport<R, S> {
     }
 }
 
-#[cfg(all(
-    any(feature = "native-tls", feature = "rustls"),
-    any(feature = "async-std", feature = "tokio")
-))]
-macro_rules! default_constructor {
-    () => {
-        /// Creates a bootstrapped `TorTransport`
-        ///
-        /// # Errors
-        ///
-        /// Could return error emitted during Tor bootstrap by Arti.
-        pub async fn bootstrapped() -> Result<Self, TorError> {
-            let builder = Self::builder();
-            let ret = Self::from_builder(builder, AddressConversion::DnsOnly)?;
-            ret.bootstrap().await?;
-            Ok(ret)
-        }
-    };
+/// Configure the onion transport from here.
+pub type TorBuilder<R> = TorClientBuilder<R>;
+
+/// Mode of address conversion
+#[derive(Debug, Clone, Copy, Hash, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AddressConversion {
+    /// Uses only dns for address resolution (default).
+    #[default]
+    DnsOnly,
+    /// uses ip and dns for addresses
+    IpAndDns,
 }
 
-#[cfg(all(feature = "native-tls", feature = "async-std"))]
-impl<S> TorTransport<tor_rtcompat::async_std::AsyncStdNativeTlsRuntime, S> {
-    pub fn builder() -> TorBuilder<tor_rtcompat::async_std::AsyncStdNativeTlsRuntime> {
-        let runtime = tor_rtcompat::async_std::AsyncStdNativeTlsRuntime::current()
-            .expect("Couldn't get the current async_std native-tls runtime");
-        TorClient::with_runtime(runtime)
-    }
-    default_constructor!();
-}
-
-#[cfg(all(feature = "rustls", feature = "async-std"))]
-impl<S> TorTransport<tor_rtcompat::async_std::AsyncStdRustlsRuntime, S> {
-    pub fn builder() -> TorBuilder<tor_rtcompat::async_std::AsyncStdRustlsRuntime> {
-        let runtime = tor_rtcompat::async_std::AsyncStdRustlsRuntime::current()
-            .expect("Couldn't get the current async_std rustls runtime");
-        TorClient::with_runtime(runtime)
-    }
-    default_constructor!();
-}
-
-#[cfg(all(feature = "native-tls", feature = "tokio"))]
-impl<S> TorTransport<tor_rtcompat::tokio::TokioNativeTlsRuntime, S> {
-    pub fn builder() -> TorBuilder<tor_rtcompat::tokio::TokioNativeTlsRuntime> {
-        let runtime = tor_rtcompat::tokio::TokioNativeTlsRuntime::current()
-            .expect("Couldn't get the current tokio native-tls runtime");
-        TorClient::with_runtime(runtime)
-    }
-    default_constructor!();
-}
-
-#[cfg(all(feature = "rustls", feature = "tokio"))]
-impl<S> TorTransport<tor_rtcompat::tokio::TokioRustlsRuntime, S> {
-    pub fn builder() -> TorBuilder<tor_rtcompat::tokio::TokioRustlsRuntime> {
-        let runtime = tor_rtcompat::tokio::TokioRustlsRuntime::current()
-            .expect("Couldn't get the current tokio rustls runtime");
-        TorClient::with_runtime(runtime)
-    }
-    default_constructor!();
-}
-
-#[cfg(all(feature = "native-tls", feature = "async-std"))]
-pub type AsyncStdNativeTlsTorTransport =
-    TorTransport<tor_rtcompat::async_std::AsyncStdNativeTlsRuntime, AsyncStdTorStream>;
-#[cfg(all(feature = "rustls", feature = "async-std"))]
-pub type AsyncStdRustlsTorTransport =
-    TorTransport<tor_rtcompat::async_std::AsyncStdRustlsRuntime, AsyncStdTorStream>;
-#[cfg(all(feature = "native-tls", feature = "tokio"))]
-pub type TokioNativeTlsTorTransport =
-    TorTransport<tor_rtcompat::tokio::TokioNativeTlsRuntime, TokioTorStream>;
-#[cfg(all(feature = "rustls", feature = "tokio"))]
-pub type TokioRustlsTorTransport =
-    TorTransport<tor_rtcompat::tokio::TokioRustlsRuntime, TokioTorStream>;
-
-#[derive(Debug, Clone, Copy, Default)]
-pub struct AlwaysErrorListenerUpgrade<S>(PhantomData<S>);
-
-impl<S> core::future::Future for AlwaysErrorListenerUpgrade<S> {
-    type Output = Result<S, TorError>;
-    fn poll(
-        self: std::pin::Pin<&mut Self>,
-        _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
-        panic!("onion services are not implented yet, since arti doesn't support it. (awaiting Arti 1.2.0)")
-    }
-}
-
-impl<R: Runtime, S> Transport for TorTransport<R, S>
-where
-    S: TorStream,
-{
-    type Output = S;
+impl Transport for TorTransport {
+    type Output = TokioTorStream;
     type Error = TorError;
     type Dial = BoxFuture<'static, Result<Self::Output, Self::Error>>;
-    type ListenerUpgrade = AlwaysErrorListenerUpgrade<Self::Output>;
+    type ListenerUpgrade = futures::future::Pending<Result<Self::Output, Self::Error>>;
 
-    /// Always returns `TransportError::MultiaddrNotSupported`
     fn listen_on(
         &mut self,
-        addr: libp2p_core::Multiaddr,
-    ) -> Result<
-        libp2p_core::transport::ListenerId,
-        libp2p_core::transport::TransportError<Self::Error>,
-    > {
-        // although this address might be supported, this is returned in order to not provoke an
-        // error when trying to listen on this transport.
-        Err(TransportError::MultiaddrNotSupported(addr))
+        _id: ListenerId,
+        _addr: Multiaddr,
+    ) -> Result<(), TransportError<Self::Error>> {
+        Err(TransportError::MultiaddrNotSupported(_addr))
     }
 
-    fn remove_listener(&mut self, _id: libp2p_core::transport::ListenerId) -> bool {
+    fn remove_listener(&mut self, _id: ListenerId) -> bool {
         false
     }
 
@@ -283,7 +149,10 @@ where
         let tor_address = maybe_tor_addr.ok_or(TransportError::MultiaddrNotSupported(addr))?;
         let onion_client = self.client.clone();
 
-        Ok(async move { onion_client.connect(tor_address).await.map(S::from) }.boxed())
+        Ok(Box::pin(async move {
+            let stream = onion_client.connect(tor_address).await?;
+            Ok(stream.into())
+        }))
     }
 
     fn dial_as_listener(
@@ -298,11 +167,9 @@ where
     }
 
     fn poll(
-        self: Pin<&mut Self>,
+        self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<libp2p_core::transport::TransportEvent<Self::ListenerUpgrade, Self::Error>>
-    {
-        // pending is returned here because this transport doesn't support listening
+    ) -> std::task::Poll<TransportEvent<Self::ListenerUpgrade, Self::Error>> {
         std::task::Poll::Pending
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! //! ## Example
 //! ```no_run
-//! use libp2p_core::Transport;
+//! use libp2p::core::Transport;
 //! # async fn test_func() -> Result<(), Box<dyn std::error::Error>> {
 //! let address = "/dns/www.torproject.org/tcp/1000".parse()?;
 //! let mut transport = libp2p_community_tor::TorTransport::bootstrapped().await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub struct TorTransport {
     // will be resolved.
     client: Arc<TorClient<TokioRustlsRuntime>>,
     /// The used conversion mode to resolve addresses. One probably shouldn't access this directly.
-    /// The usage of [TorTransport::with_address_conversion] at construction is recommended.
+    /// The usage of [`TorTransport::with_address_conversion`] at construction is recommended.
     pub conversion_mode: AddressConversion,
 }
 
@@ -91,6 +91,10 @@ pub enum AddressConversion {
 }
 
 impl TorTransport {
+    /// Creates a new `TorClientBuilder`.
+    ///
+    /// # Panics
+    /// Panics if the current runtime is not a `TokioRustlsRuntime`.
     pub fn builder() -> TorClientBuilder<TokioRustlsRuntime> {
         let runtime =
             TokioRustlsRuntime::current().expect("Couldn't get the current tokio rustls runtime");
@@ -103,14 +107,17 @@ impl TorTransport {
     /// Could return error emitted during Tor bootstrap by Arti.
     pub async fn bootstrapped() -> Result<Self, TorError> {
         let builder = Self::builder();
-        let ret = Self::from_builder(builder, AddressConversion::DnsOnly)?;
+        let ret = Self::from_builder(&builder, AddressConversion::DnsOnly)?;
         ret.bootstrap().await?;
         Ok(ret)
     }
 
-    /// Builds a `TorTransport` from an Arti `TorClientBuilder`.
+    /// Builds a `TorTransport` from an Arti `TorClientBuilder` but does not bootstrap it.
+    ///
+    /// # Errors
+    /// Could return error emitted during creation of the `TorClient`.
     pub fn from_builder(
-        builder: TorClientBuilder<TokioRustlsRuntime>,
+        builder: &TorClientBuilder<TokioRustlsRuntime>,
         conversion_mode: AddressConversion,
     ) -> Result<Self, TorError> {
         let client = Arc::new(builder.create_unbootstrapped()?);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,9 +79,6 @@ pub struct TorTransport {
     pub conversion_mode: AddressConversion,
 }
 
-/// Configure the onion transport from here.
-pub type TorBuilder<TokioRustlsRuntime> = TorClientBuilder<TokioRustlsRuntime>;
-
 /// Mode of address conversion.
 /// Refer tor [arti_client::TorAddr](https://docs.rs/arti-client/latest/arti_client/struct.TorAddr.html) for details
 #[derive(Debug, Clone, Copy, Hash, Default, PartialEq, Eq, PartialOrd, Ord)]
@@ -94,7 +91,7 @@ pub enum AddressConversion {
 }
 
 impl TorTransport {
-    pub fn builder() -> TorBuilder<TokioRustlsRuntime> {
+    pub fn builder() -> TorClientBuilder<TokioRustlsRuntime> {
         let runtime =
             TokioRustlsRuntime::current().expect("Couldn't get the current tokio rustls runtime");
         TorClient::with_runtime(runtime)
@@ -113,7 +110,7 @@ impl TorTransport {
 
     /// Builds a `TorTransport` from an Arti `TorClientBuilder`.
     pub fn from_builder(
-        builder: TorBuilder<TokioRustlsRuntime>,
+        builder: TorClientBuilder<TokioRustlsRuntime>,
         conversion_mode: AddressConversion,
     ) -> Result<Self, TorError> {
         let client = Arc::new(builder.create_unbootstrapped()?);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,18 @@
 //! This crate uses tokio with rustls for its runtime and TLS implementation.
 //! No other combinations are supported.
 //!
-//! Main entrypoint of the crate: [`TorTransport`]
+//! //! ## Example
+//! ```no_run
+//! use libp2p_core::Transport;
+//! # async fn test_func() -> Result<(), Box<dyn std::error::Error>> {
+//! let address = "/dns/www.torproject.org/tcp/1000".parse()?;
+//! let mut transport = libp2p_community_tor::TorTransport::bootstrapped().await?;
+//! // we have achieved tor connection
+//! let _conn = transport.dial(address)?.await?;
+//! # Ok(())
+//! # }
+//! # tokio_test::block_on(test_func());
+//! ```
 
 use arti_client::{TorClient, TorClientBuilder};
 use futures::future::BoxFuture;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,18 @@ pub use provider::AsyncStdTorStream;
 pub type TorError = arti_client::Error;
 
 #[derive(Clone)]
-pub struct TorTransport<R: Runtime, S> {
+pub struct TorTransport<R, S>
+where
+    R: Runtime
+        + BlockOn
+        + SleepProvider
+        + UdpProvider
+        + CoarseTimeProvider
+        + NetStreamProvider
+        + NetStreamProvider<std::os::unix::net::SocketAddr>
+        + TlsProvider<S>,
+    S: TorStream,
+{
     // client is in an Arc, because without it the [`Transport::dial`] method can't be implemented,
     // due to lifetime issues. With the, eventual, stabilization of static async traits this issue
     // will be resolved.

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -22,10 +22,6 @@ use arti_client::DataStream;
 use futures::{AsyncRead, AsyncWrite};
 use tokio::io::{AsyncRead as TokioAsyncRead, AsyncWrite as TokioAsyncWrite, ReadBuf};
 
-pub trait TorStream: AsyncRead + AsyncWrite + From<DataStream> {}
-
-impl TorStream for DataStream {}
-
 #[derive(Debug)]
 pub struct TokioTorStream {
     inner: DataStream,
@@ -36,8 +32,6 @@ impl From<DataStream> for TokioTorStream {
         Self { inner }
     }
 }
-
-impl TorStream for TokioTorStream {}
 
 impl AsyncRead for TokioTorStream {
     fn poll_read(


### PR DESCRIPTION
This PR:
- Bumps the `libp2p` crate version to [0.53](https://crates.io/crates/libp2p/0.53.2)
- Bumps the `arti_client` crate to [0.24](https://crates.io/crates/arti-client/0.24.0)
- Removes support for runtime agnonstic use of this crate. We force users to use [tokio](https://crates.io/crates/tokio) + [rustls](https://crates.io/crates/rustls)
- Adds a new `TorTransport::from_client` builder method to construct a transport from an already existing Arti client

Closes https://github.com/umgefahren/libp2p-tor/issues/17