### PR TITLE
feat: Listen on onion-service, dial onion services

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,19 +9,39 @@ repository = "https://github.com/umgefahren/libp2p-tor"
 authors = ["umgefahren <hannes@umgefahren.xyz>"]
 
 [dependencies]
-arti-client = { version = "0.24", default-features = false, features = ["tokio", "rustls"] }
+thiserror = "1.0"
+anyhow = "1.0.93"
+tokio = "1.41.1"
 futures = "0.3"
+
+arti-client = { version = "0.24", default-features = false, features = ["tokio", "rustls", "onion-service-client"] }
 libp2p = { version = "^0.53", default-features = false, features = ["tokio", "tcp", "tls"] }
+
 tor-rtcompat = { version = "0.24.0", features = ["tokio", "rustls"] }
-tokio = { version = "1.0", features = ["macros"] }
 tracing = "0.1.40"
+tor-hsservice = { version = "0.24.0", optional = true }
+tor-cell = { version = "0.24.0", optional = true }
+tor-proto = { version = "0.24.0", optional = true }
+data-encoding = { version = "2.6.0", optional = true }
 
 [dev-dependencies]
 libp2p = { version = "0.53", default-features = false, features = ["tokio", "noise", "yamux", "ping", "macros", "tcp", "tls"] }
 tokio-test = "0.4.4"
+tokio = { version = "1.41.1", features = ["macros"] }
+tracing-subscriber = "0.2"
+
+[features]
+listen-onion-service = [
+    "arti-client/onion-service-service",
+    "dep:tor-hsservice",
+    "dep:tor-cell",
+    "dep:tor-proto",
+    "dep:data-encoding"
+]
 
 [[example]]
 name = "ping-onion"
+required-features = ["listen-onion-service"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/umgefahren/libp2p-tor"
 authors = ["umgefahren <hannes@umgefahren.xyz>"]
 
 [dependencies]
-arti-client = "0.24.0"
+arti-client = { version = "0.24", default-features = false, features = ["tokio", "rustls"] }
 futures = "0.3"
 libp2p = { version = "^0.53", default-features = false, features = ["tokio", "tcp", "tls"] }
 tor-rtcompat = { version = "0.24.0", features = ["tokio", "rustls"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,6 +394,12 @@ impl Transport for TorTransport {
         for (listener_id, listener) in self.listeners.iter_mut() {
             // Check if the service has any new statuses
             if let Poll::Ready(Some(status)) = listener.status_stream.as_mut().poll_next(cx) {
+                tracing::debug!(
+                    status = ?status.state(),
+                    address = listener.onion_address.to_string(),
+                    "Onion service status changed"
+                );
+
                 if status.is_reachable() {
                     // TODO: We might report the address here multiple time to the swarm. Is this a problem?
                     return Poll::Ready(TransportEvent::NewAddress {


### PR DESCRIPTION
This PR adds support for listening on onion services (`/onion3/*:x/` addresses, where `*` is an onion address and `x` an arbitrary port)

It also add support for dialing them.

Closes https://github.com/umgefahren/libp2p-tor/issues/19