### PR TITLE
chore: Explicitly disable native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/umgefahren/libp2p-tor"
 authors = ["umgefahren <hannes@umgefahren.xyz>"]
 
 [dependencies]
-arti-client = { version = "0.8", default-features = false }
+arti-client = { version = "0.24", default-features = false, features = ["tokio", "rustls"] }
 async-std-crate = { package = "async-std", version = "1", optional = true, default-features = false }
 futures = "0.3"
 libp2p-core = { version = "0.39" }


### PR DESCRIPTION
We force users to use `rustls` therefore we should explicitly disable the `native-tls` feature.