### PR TITLE
fix: Compilation without feature flags, clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,11 @@ jobs:
       
       - uses: Swatinem/rust-cache@v2
 
-      - name: Run all tests
+      - name: Run tests with all features enabled
         run: cargo test --all-features
+
+      - name: Run tests without features enabled
+        run: cargo test
 
   clippy:
     name: Clippy
@@ -57,8 +60,11 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Run cargo clippy
+      - name: Run cargo clippy with all features enabled
         run: cargo clippy --all-features
+
+      - name: Run cargo clippy without any features enabled
+        run: cargo clippy
 
   rustfmt:
     name: Rust format

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tracing = "0.1.40"
 tor-hsservice = { version = "0.24.0", optional = true }
 tor-cell = { version = "0.24.0", optional = true }
 tor-proto = { version = "0.24.0", optional = true }
-data-encoding = { version = "2.6.0", optional = true }
+data-encoding = { version = "2.6.0" }
 
 [dev-dependencies]
 libp2p = { version = "0.53", default-features = false, features = ["tokio", "noise", "yamux", "ping", "macros", "tcp", "tls"] }
@@ -35,8 +35,7 @@ listen-onion-service = [
     "arti-client/onion-service-service",
     "dep:tor-hsservice",
     "dep:tor-cell",
-    "dep:tor-proto",
-    "dep:data-encoding"
+    "dep:tor-proto"
 ]
 
 [[example]]

--- a/src/address.rs
+++ b/src/address.rs
@@ -53,14 +53,14 @@ pub fn safe_extract(multiaddr: &Multiaddr) -> Option<TorAddr> {
 
 fn libp2p_onion_address_to_domain_and_port<'a>(
     onion_address: &'a Onion3Addr<'_>,
-) -> Option<(&'a str, u16)> {
+) -> (&'a str, u16) {
     // Here we convert from Onion3Addr to TorAddr
     // We need to leak the string because it's a temporary string that would otherwise be freed
     let hash = data_encoding::BASE32.encode(onion_address.hash());
-    let onion_domain = format!("{}.onion", hash);
+    let onion_domain = format!("{hash}.onion");
     let onion_domain = Box::leak(onion_domain.into_boxed_str());
 
-    Some((onion_domain, onion_address.port()))
+    (onion_domain, onion_address.port())
 }
 
 fn try_to_domain_and_port<'a>(
@@ -72,7 +72,7 @@ fn try_to_domain_and_port<'a>(
             Protocol::Dns(domain) | Protocol::Dns4(domain) | Protocol::Dns6(domain),
             Some(Protocol::Tcp(port)),
         ) => Some((domain.as_ref(), *port)),
-        (Protocol::Onion3(domain), _) => libp2p_onion_address_to_domain_and_port(domain),
+        (Protocol::Onion3(domain), _) => Some(libp2p_onion_address_to_domain_and_port(domain)),
         _ => None,
     }
 }


### PR DESCRIPTION
I have rebased this on https://github.com/umgefahren/libp2p-tor/pull/28 to show that the tests are passing.

Closes https://github.com/umgefahren/libp2p-tor/issues/27