### PR TITLE
fix: Immediately announce onion address to swarm 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,11 @@ jobs:
       
       - uses: Swatinem/rust-cache@v2
 
-      - name: Run all tests
+      - name: Run tests with all features enabled
         run: cargo test --all-features
+
+      - name: Run tests without features enabled
+        run: cargo test
 
   clippy:
     name: Clippy
@@ -57,8 +60,11 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Run cargo clippy
+      - name: Run cargo clippy with all features enabled
         run: cargo clippy --all-features
+
+      - name: Run cargo clippy without any features enabled
+        run: cargo clippy
 
   rustfmt:
     name: Rust format

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tracing = "0.1.40"
 tor-hsservice = { version = "0.24.0", optional = true }
 tor-cell = { version = "0.24.0", optional = true }
 tor-proto = { version = "0.24.0", optional = true }
-data-encoding = { version = "2.6.0", optional = true }
+data-encoding = { version = "2.6.0" }
 
 [dev-dependencies]
 libp2p = { version = "0.53", default-features = false, features = ["tokio", "noise", "yamux", "ping", "macros", "tcp", "tls"] }
@@ -35,8 +35,7 @@ listen-onion-service = [
     "arti-client/onion-service-service",
     "dep:tor-hsservice",
     "dep:tor-cell",
-    "dep:tor-proto",
-    "dep:data-encoding"
+    "dep:tor-proto"
 ]
 
 [[example]]

--- a/examples/ping-onion.rs
+++ b/examples/ping-onion.rs
@@ -130,10 +130,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         swarm.dial(remote)?;
         println!("Dialed {addr}")
     } else {
-        // TODO: We need to do this because otherwise the status of the onion service is gonna be [`Shutdown`]
-        // when we first poll it and then the swarm will not pull it again (?). I don't know why this is the case.
-        tokio::time::sleep(std::time::Duration::from_secs(20)).await;
-
         // If we are not dialing, we need to listen
         // Tell the swarm to listen on a specific onion address
         swarm.listen_on(onion_listen_address).unwrap();

--- a/src/address.rs
+++ b/src/address.rs
@@ -53,14 +53,14 @@ pub fn safe_extract(multiaddr: &Multiaddr) -> Option<TorAddr> {
 
 fn libp2p_onion_address_to_domain_and_port<'a>(
     onion_address: &'a Onion3Addr<'_>,
-) -> Option<(&'a str, u16)> {
+) -> (&'a str, u16) {
     // Here we convert from Onion3Addr to TorAddr
     // We need to leak the string because it's a temporary string that would otherwise be freed
     let hash = data_encoding::BASE32.encode(onion_address.hash());
-    let onion_domain = format!("{}.onion", hash);
+    let onion_domain = format!("{hash}.onion");
     let onion_domain = Box::leak(onion_domain.into_boxed_str());
 
-    Some((onion_domain, onion_address.port()))
+    (onion_domain, onion_address.port())
 }
 
 fn try_to_domain_and_port<'a>(
@@ -72,7 +72,7 @@ fn try_to_domain_and_port<'a>(
             Protocol::Dns(domain) | Protocol::Dns4(domain) | Protocol::Dns6(domain),
             Some(Protocol::Tcp(port)),
         ) => Some((domain.as_ref(), *port)),
-        (Protocol::Onion3(domain), _) => libp2p_onion_address_to_domain_and_port(domain),
+        (Protocol::Onion3(domain), _) => Some(libp2p_onion_address_to_domain_and_port(domain)),
         _ => None,
     }
 }


### PR DESCRIPTION
Depends on: https://github.com/umgefahren/libp2p-tor/pull/31

Instead of waiting for the onion service to be fully reachable (registered at intro points and hs_dirs), we announce the address immediately.

We announce the address immediately to the swarm even though we technically cannot guarantee that the address is reachable yet from the outside. We might not have registered the onion service fully yet (introduction points, hsdir, ...)
However, we need to announce it as soon as possible because otherwise libp2p might not poll the listener again and we will not be able to announce it later.