### PR TITLE
chore: update libp2p to 0.55

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ tokio = "1.41.1"
 futures = "0.3"
 
 arti-client = { version = "^0.25", default-features = false, features = ["tokio", "rustls", "onion-service-client", "static-sqlite"] }
-libp2p = { version = "^0.53", default-features = false, features = ["tokio", "tcp", "tls"] }
+libp2p = { version = "^0.55.0", default-features = false, features = ["tokio", "tcp", "tls"] }
 
 tor-rtcompat = { version = "^0.25", features = ["tokio", "rustls"] }
 tracing = "0.1.40"
@@ -25,7 +25,7 @@ tor-proto = { version = "^0.25", optional = true }
 data-encoding = { version = "2.6.0" }
 
 [dev-dependencies]
-libp2p = { version = "0.53", default-features = false, features = ["tokio", "noise", "yamux", "ping", "macros", "tcp", "tls"] }
+libp2p = { version = "0.55.0", default-features = false, features = ["tokio", "noise", "yamux", "ping", "macros", "tcp", "tls"] }
 tokio-test = "0.4.4"
 tokio = { version = "1.41.1", features = ["macros"] }
 tracing-subscriber = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,11 +67,11 @@ use thiserror::Error;
 use tor_rtcompat::tokio::TokioRustlsRuntime;
 
 // We only need these imports if the `listen-onion-service` feature is enabled
+use libp2p::core::transport::DialOpts;
 #[cfg(feature = "listen-onion-service")]
 use std::collections::HashMap;
 #[cfg(feature = "listen-onion-service")]
 use std::str::FromStr;
-use libp2p::core::transport::DialOpts;
 #[cfg(feature = "listen-onion-service")]
 use tor_cell::relaycell::msg::{Connected, End, EndReason};
 #[cfg(feature = "listen-onion-service")]
@@ -353,7 +353,11 @@ impl Transport for TorTransport {
         false
     }
 
-    fn dial(&mut self, addr: Multiaddr, _: DialOpts) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(
+        &mut self,
+        addr: Multiaddr,
+        _: DialOpts,
+    ) -> Result<Self::Dial, TransportError<Self::Error>> {
         let maybe_tor_addr = match self.conversion_mode {
             AddressConversion::DnsOnly => safe_extract(&addr),
             AddressConversion::IpAndDns => dangerous_extract(&addr),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,12 +40,15 @@
 //!
 //! ## Example
 //! ```no_run
-//! use libp2p::core::Transport;
+//! use libp2p::core::{Endpoint, Transport};
+//! use libp2p::core::transport::{DialOpts, PortUse};
+//!
 //! # async fn test_func() -> Result<(), Box<dyn std::error::Error>> {
 //! let address = "/dns/www.torproject.org/tcp/1000".parse()?;
 //! let mut transport = libp2p_community_tor::TorTransport::bootstrapped().await?;
+//! let opt = DialOpts { port_use: PortUse::New, role: Endpoint::Dialer };
 //! // we have achieved tor connection
-//! let _conn = transport.dial(address)?.await?;
+//! let _conn = transport.dial(address, opt)?.await?;
 //! # Ok(())
 //! # }
 //! # tokio_test::block_on(test_func());
@@ -68,6 +71,7 @@ use tor_rtcompat::tokio::TokioRustlsRuntime;
 use std::collections::HashMap;
 #[cfg(feature = "listen-onion-service")]
 use std::str::FromStr;
+use libp2p::core::transport::DialOpts;
 #[cfg(feature = "listen-onion-service")]
 use tor_cell::relaycell::msg::{Connected, End, EndReason};
 #[cfg(feature = "listen-onion-service")]
@@ -349,7 +353,7 @@ impl Transport for TorTransport {
         false
     }
 
-    fn dial(&mut self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(&mut self, addr: Multiaddr, _: DialOpts) -> Result<Self::Dial, TransportError<Self::Error>> {
         let maybe_tor_addr = match self.conversion_mode {
             AddressConversion::DnsOnly => safe_extract(&addr),
             AddressConversion::IpAndDns => dangerous_extract(&addr),
@@ -366,17 +370,6 @@ impl Transport for TorTransport {
 
             Ok(TokioTorStream::from(stream))
         }))
-    }
-
-    fn dial_as_listener(
-        &mut self,
-        addr: Multiaddr,
-    ) -> Result<Self::Dial, TransportError<Self::Error>> {
-        self.dial(addr)
-    }
-
-    fn address_translation(&self, _listen: &Multiaddr, _observed: &Multiaddr) -> Option<Multiaddr> {
-        None
     }
 
     #[cfg(not(feature = "listen-onion-service"))]


### PR DESCRIPTION
This removes the deprecated trait members and add the DialOpts to `Transport::dial`

supersede #44 